### PR TITLE
fix embed not working with -o

### DIFF
--- a/cmd/pkger/cmds/pack.go
+++ b/cmd/pkger/cmds/pack.go
@@ -53,7 +53,7 @@ func (e *packCmd) Exec(args []string) error {
 		return err
 	}
 
-	if err := Package(fp, decls); err != nil {
+	if err := Package(info, fp, decls); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (e *packCmd) Flags() *flag.FlagSet {
 	return e.FlagSet
 }
 
-func Package(out string, decls parser.Decls) error {
+func Package(info here.Info, out string, decls parser.Decls) error {
 	os.RemoveAll(out)
 	defer func() {
 		if err := recover(); err != nil {
@@ -146,7 +146,7 @@ func Package(out string, decls parser.Decls) error {
 	fmt.Fprintf(f, "import \"github.com/markbates/pkger/pkging/mem\"\n\n")
 	fmt.Fprintf(f, "\nvar _ = pkger.Apply(mem.UnmarshalEmbed([]byte(`")
 
-	if err := pkgutil.Stuff(f, c, decls); err != nil {
+	if err := pkgutil.Stuff(f, info, decls); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Hi,

It seems that the embed impl won't work with the new -o option.

Here's a diff of the walk example showing the problem:

```diff
diff --git a/examples/walk/pkger/Makefile b/examples/walk/pkger/Makefile
index dd14cf3..a04eaee 100644
--- a/examples/walk/pkger/Makefile
+++ b/examples/walk/pkger/Makefile
@@ -1,5 +1,5 @@
 default:
-       pkger
+       pkger -o pkged
        GOOS=linux go build -v -o example
        docker build -t pkger:example .
        docker run -p 3000:3000 pkger:example
diff --git a/examples/walk/pkger/main.go b/examples/walk/pkger/main.go
index 450d65e..3bb583d 100644
--- a/examples/walk/pkger/main.go
+++ b/examples/walk/pkger/main.go
@@ -8,6 +8,8 @@ import (
        "time"
 
        "github.com/markbates/pkger"
+
+       _ "app/pkged"
 )
 
 func main() {
diff --git a/examples/walk/pkger/pkged/package.go b/examples/walk/pkger/pkged/package.go
new file mode 100644
index 0000000..dee4673
--- /dev/null
+++ b/examples/walk/pkger/pkged/package.go
@@ -0,0 +1 @@
+package pkged
```

Here's what I did:
 - Create a new package `app/pkged` with just a `package.go`
 - "Blank import" it from `main.go`

Go run the example without running pkger works fine.

After running `pkger -o pkged` doesn't work anymore.

I'm not sure how to write a test for this... but the fix works for the walk example and hopefully for all the other cases.

Thank you for your work.