### PR TITLE
missing File.reader initialization on Seek()

### DIFF
--- a/pkging/mem/file.go
+++ b/pkging/mem/file.go
@@ -31,6 +31,10 @@ type File struct {
 
 // Seek sets the offset for the next Read or Write on file to offset, interpreted according to whence: 0 means relative to the origin of the file, 1 means relative to the current offset, and 2 means relative to the end. It returns the new offset and an error, if any.
 func (f *File) Seek(ofpkginget int64, whence int) (int64, error) {
+	if len(f.data) > 0 && f.reader == nil {
+		f.reader = bytes.NewReader(f.data)
+	}
+
 	if sk, ok := f.reader.(io.Seeker); ok {
 		return sk.Seek(ofpkginget, whence)
 	}

--- a/pkging/mem/file_test.go
+++ b/pkging/mem/file_test.go
@@ -1,7 +1,6 @@
 package mem
 
 import (
-	"io"
 	"io/ioutil"
 	"testing"
 
@@ -29,7 +28,7 @@ func Test_File_Seek(t *testing.T) {
 	r.NoError(err)
 
 	// seek to end of file before read
-	pos, err := f.Seek(0, io.SeekEnd)
+	pos, err := f.Seek(0, 2)
 	r.NoError(err)
 	r.Equal(int64(len(data)), pos)
 

--- a/pkging/mem/file_test.go
+++ b/pkging/mem/file_test.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -26,6 +27,16 @@ func Test_File_Seek(t *testing.T) {
 
 	f, err = pkg.Open(":/wilco.band")
 	r.NoError(err)
+
+	// seek to end of file before read
+	pos, err := f.Seek(0, io.SeekEnd)
+	r.NoError(err)
+	r.Equal(int64(len(data)), pos)
+
+	// reset seek
+	pos, err = f.Seek(0, 0)
+	r.NoError(err)
+	r.Equal(int64(0), pos)
 
 	b, err := ioutil.ReadAll(f)
 	r.NoError(err)


### PR DESCRIPTION
Currently, if you call Seek() before Read(), it returns the default value of 0 which results in unexpected behavior. I noticed this when passing a File to [http.ServeContent](https://golang.org/src/net/http/fs.go#L153).  Since it calls Seek() to generate the file size before copying the data to the ResponseWriter, the response body would be empty.
