### PR TITLE
Fixed import block (generated pkged.go file)

### DIFF
--- a/cmd/pkger/cmds/pack.go
+++ b/cmd/pkger/cmds/pack.go
@@ -142,9 +142,9 @@ func Package(info here.Info, out string, decls parser.Decls) error {
 		return err
 	}
 	fmt.Fprintf(f, "package %s\n\n", c.Name)
-	fmt.Fprintf(f, "import \"github.com/markbates/pkger\"\n\n")
-	fmt.Fprintf(f, "import \"github.com/markbates/pkger/pkging/mem\"\n\n")
-	fmt.Fprintf(f, "\nvar _ = pkger.Apply(mem.UnmarshalEmbed([]byte(`")
+	fmt.Fprintf(f, "import (\n\t\"github.com/markbates/pkger\"\n\t")
+	fmt.Fprintf(f, "\"github.com/markbates/pkger/pkging/mem\"\n)\n\n")
+	fmt.Fprintf(f, "var _ = pkger.Apply(mem.UnmarshalEmbed([]byte(`")
 
 	if err := pkgutil.Stuff(f, info, decls); err != nil {
 		return err


### PR DESCRIPTION
Turn this:

```go
package main

import "github.com/markbates/pkger"

import "github.com/markbates/pkger/pkging/mem"


var _ = pkger.Apply(...)

```

To this:

```go
package main

import (
	"github.com/markbates/pkger"
	"github.com/markbates/pkger/pkging/mem"
)

var _ = pkger.Apply(...)

```

I know, `pkged.go` is a service file, but I could not pass by.. sorry :)