### PR TITLE
Don't force the package to 'main' if the '-o' option was used.

### DIFF
--- a/cmd/pkger/cmds/pack.go
+++ b/cmd/pkger/cmds/pack.go
@@ -137,13 +137,14 @@ func Package(info here.Info, out string, decls parser.Decls) error {
 	}
 	defer f.Close()
 
-	c, err := here.Dir(filepath.Dir(out))
+	dir := filepath.Dir(out)
+	c, err := here.Dir(dir)
 	if err != nil {
 		return err
 	}
 
 	name := c.Name
-	if info.Module.Main {
+	if dir == info.Dir && info.Module.Main {
 		name = "main"
 	}
 


### PR DESCRIPTION
It looks like the problem is that pkger gets the information for the current
directory, *then* appends the path from the '-o' option, but that means that
the package name will always be main if it's started from the main package,
regardless of '-o'.

Fixes #56.