### PR TITLE
Clarify path limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ github.com/markbates/pkger:/cmd/pkger/main.go
 "github.com/gobuffalo/buffalo:/go.mod" => $GOPATH/pkg/mod/github.com/gobuffalo/buffalo@v0.14.7/go.mod
 ```
 
+## Limitations
+
+It is not possible to embed files using variables nor constants:
+
+```
+var path = "/file.txt"
+file, err := pkger.Open(path) // not possible
+
+const path = "/file.txt"
+file, err := pkger.Open(path) // not possible
+```
+
+You may only use string literals to open files:
+
+```
+file, err := pkger.Open("/file.txt") // possible
+```
+
 ## CLI
 
 ### Installation


### PR DESCRIPTION
It is not possible to embed files that are not specified using `pkger.*` and a string literal. This caveat is a decisive factor in some environments and should be documented as such in a prominent way.