### PR TITLE
Fixes high cache miss rate, significant performance increase.

### DIFF
--- a/cmd/pkger/cmds/pack.go
+++ b/cmd/pkger/cmds/pack.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gobuffalo/here"
 	"github.com/markbates/pkger"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/parser"
 	"github.com/markbates/pkger/pkging/pkgutil"
 )

--- a/cmd/pkger/cmds/parse.go
+++ b/cmd/pkger/cmds/parse.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"os"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/parser"
 )
 

--- a/cmd/pkger/cmds/path.go
+++ b/cmd/pkger/cmds/path.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gobuffalo/here"
 	"github.com/markbates/pkger"
+	"github.com/markbates/pkger/here"
 )
 
 type pathCmd struct {

--- a/here/here.go
+++ b/here/here.go
@@ -8,6 +8,7 @@ type Info = here.Info
 type Module = here.Module
 type Path = here.Path
 
-var Dir = here.Dir
-var Package = here.Package
-var Current = here.Current
+var Here = here.New()
+var Dir = Here.Dir
+var Package = Here.Package
+var Current = Here.Current

--- a/internal/maps/files.go
+++ b/internal/maps/files.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/internal/maps/infos.go
+++ b/internal/maps/infos.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 // Infos wraps sync.Map and uses the following types:

--- a/parser/file.go
+++ b/parser/file.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"encoding/json"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 type File struct {

--- a/parser/include.go
+++ b/parser/include.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 var _ Decl = IncludeDecl{}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 var defaultIgnoredFolders = []string{".", "_", "vendor", "node_modules", "testdata"}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging/pkgtest"
 	"github.com/markbates/pkger/pkging/stdos"
 	"github.com/stretchr/testify/require"

--- a/parser/source.go
+++ b/parser/source.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 type Source struct {

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 var _ Decl = WalkDecl{}

--- a/pkger.go
+++ b/pkger.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 	"github.com/markbates/pkger/pkging/stdos"
 )

--- a/pkging/embed/embed.go
+++ b/pkging/embed/embed.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"io"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/internal/takeon/github.com/markbates/hepa"
 	"github.com/markbates/pkger/internal/takeon/github.com/markbates/hepa/filters"
 )

--- a/pkging/embed/file.go
+++ b/pkging/embed/file.go
@@ -1,7 +1,7 @@
 package embed
 
 import (
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/file.go
+++ b/pkging/file.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 type File interface {

--- a/pkging/file_info_test.go
+++ b/pkging/file_info_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 	"github.com/stretchr/testify/require"
 )

--- a/pkging/mem/add.go
+++ b/pkging/mem/add.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/mem/add_test.go
+++ b/pkging/mem/add_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging/mem"
 	"github.com/stretchr/testify/require"
 )

--- a/pkging/mem/embed.go
+++ b/pkging/mem/embed.go
@@ -3,7 +3,7 @@ package mem
 import (
 	"encoding/json"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/internal/maps"
 	"github.com/markbates/pkger/pkging"
 	"github.com/markbates/pkger/pkging/embed"

--- a/pkging/mem/file.go
+++ b/pkging/mem/file.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/mem/file_test.go
+++ b/pkging/mem/file_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkging/mem/mem.go
+++ b/pkging/mem/mem.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/internal/maps"
 	"github.com/markbates/pkger/pkging"
 )

--- a/pkging/pkger.go
+++ b/pkging/pkger.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 type Pkger interface {

--- a/pkging/pkgtest/load_ref.go
+++ b/pkging/pkgtest/load_ref.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/pkgtest/pkgtest.go
+++ b/pkging/pkgtest/pkgtest.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 	"github.com/stretchr/testify/require"
 )

--- a/pkging/pkgtest/ref.go
+++ b/pkging/pkgtest/ref.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 type Ref struct {

--- a/pkging/pkgutil/dump.go
+++ b/pkging/pkgutil/dump.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/pkgutil/stuff.go
+++ b/pkging/pkgutil/stuff.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/parser"
 	"github.com/markbates/pkger/pkging/embed"
 	"github.com/markbates/pkger/pkging/mem"

--- a/pkging/stdos/file.go
+++ b/pkging/stdos/file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/pkging"
 )
 

--- a/pkging/stdos/file_test.go
+++ b/pkging/stdos/file_test.go
@@ -3,7 +3,7 @@ package stdos
 import (
 	"testing"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkging/stdos/stdos.go
+++ b/pkging/stdos/stdos.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 	"github.com/markbates/pkger/internal/maps"
 	"github.com/markbates/pkger/pkging"
 )

--- a/pkging/wrap.go
+++ b/pkging/wrap.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gobuffalo/here"
+	"github.com/markbates/pkger/here"
 )
 
 func Wrap(parent, with Pkger) Pkger {


### PR DESCRIPTION
Closes #92 
Relates to #58 

By using gobuffalo/here directly, a new cache was being created very frequently. By using a single reference to a gobuffalo/here Here object, we can use all local imports and preserve the cache. This sped up performance significantly (30 minutes to 5 seconds)

Main file change:
https://github.com/markbates/pkger/pull/93/files#diff-f410a002f8798205cec6c28ec8dd3db4

All other files are replacing imports.

Tests passing
```
$ go test -v
=== RUN   Test_Parse
--- PASS: Test_Parse (0.00s)
=== RUN   Test_Current
--- PASS: Test_Current (0.00s)
=== RUN   Test_Info
--- PASS: Test_Info (0.00s)
=== RUN   Test_Create
--- PASS: Test_Create (0.00s)
=== RUN   Test_MkdirAll
--- PASS: Test_MkdirAll (0.00s)
=== RUN   Test_Stat
--- PASS: Test_Stat (0.00s)
=== RUN   Test_Walk
--- PASS: Test_Walk (0.00s)
=== RUN   Test_Remove
--- PASS: Test_Remove (0.00s)
PASS
ok      github.com/markbates/pkger      0.317s
```