### PR TITLE
Support const paths

### DIFF
--- a/pkging/pkgtest/testdata/ref/main.go
+++ b/pkging/pkgtest/testdata/ref/main.go
@@ -18,12 +18,16 @@ func main() {
 	}
 }
 
+const (
+	unused, pathAsset = "", "/assets"
+)
+
 func run() error {
 	if err := actions.WalkTemplates(os.Stdout); err != nil {
 		return err
 	}
 
-	err := pkger.Walk("/assets", func(path string, info os.FileInfo, err error) error {
+	err := pkger.Walk(pathAsset, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR extends the parsing to support constant strings, as they cannot be modified at any time, so is safe to retrieve its values while doing the static parsing.

Updates #60.

