### PR TITLE
Apply hepa filters before gzip'ing content

### DIFF
--- a/pkging/embed/embed.go
+++ b/pkging/embed/embed.go
@@ -31,6 +31,15 @@ func Decode(src []byte) ([]byte, error) {
 }
 
 func Encode(b []byte) ([]byte, error) {
+	hep := hepa.New()
+	hep = hepa.With(hep, filters.Home())
+	hep = hepa.With(hep, filters.Golang())
+
+	b, err := hep.Filter(b)
+	if err != nil {
+		return nil, err
+	}
+
 	bb := &bytes.Buffer{}
 	gz := gzip.NewWriter(bb)
 
@@ -46,16 +55,7 @@ func Encode(b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	hep := hepa.New()
-	hep = hepa.With(hep, filters.Home())
-	hep = hepa.With(hep, filters.Golang())
-
-	b, err := hep.Filter(bb.Bytes())
-	if err != nil {
-		return nil, err
-	}
-
-	s := hex.EncodeToString(b)
+	s := hex.EncodeToString(bb.Bytes())
 	return []byte(s), nil
 }
 


### PR DESCRIPTION
While there will be some plain-text header data in the gzipped payload, running the hepa filter byte replace functions should be performed before compression.

- markbates/pkger#26