### PR TITLE
Add exclude flag to list and pack commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ package <reader>
 // Pkger stuff here
 ```
 
-### Including Files at Package Time
+### Including and Excluding Files at Package Time
 
 There may be reasons where you don't reference a particular file, or folder, that you want embedded in your application, such as a build artifact.
 
 To do this you may use either the [`github.com/markbates/pkger#Include`](https://godoc.org/github.com/markbates/pkger#Include) function to set a no-op parser directive to include the specified path.
 
-Alternatively, you may use the `-include` flag with the `pkger` and `pkger list` commands.
+Alternatively, you may use the `-include` flag with the `pkger` and `pkger list` commands. To exclude files and directories when parsing, you may additionally use the `-exclude` flag. Directories such as `node_modules` are excluded by default.
 
 ```bash
 $ pkger list -include /actions -include github.com/gobuffalo/buffalo:/app.go

--- a/cmd/pkger/cmds/list.go
+++ b/cmd/pkger/cmds/list.go
@@ -44,7 +44,7 @@ func (e *listCmd) Exec(args []string) error {
 	fp := filepath.Join(info.Dir, outName)
 	os.RemoveAll(fp)
 
-	decls, err := parser.Parse(info, e.include...)
+	decls, err := parser.Parse(info, e.include, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/pkger/cmds/list.go
+++ b/cmd/pkger/cmds/list.go
@@ -19,6 +19,7 @@ type listCmd struct {
 	help    bool
 	json    bool
 	include slice
+	exclude slice
 	subs    []command
 }
 
@@ -44,7 +45,7 @@ func (e *listCmd) Exec(args []string) error {
 	fp := filepath.Join(info.Dir, outName)
 	os.RemoveAll(fp)
 
-	decls, err := parser.Parse(info, e.include, nil)
+	decls, err := parser.Parse(info, e.include, e.exclude)
 	if err != nil {
 		return err
 	}
@@ -95,6 +96,7 @@ func (e *listCmd) Flags() *flag.FlagSet {
 		e.FlagSet = flag.NewFlagSet("list", flag.ExitOnError)
 		e.BoolVar(&e.json, "json", false, "prints in JSON format")
 		e.Var(&e.include, "include", "packages the specified file or directory")
+		e.Var(&e.exclude, "exclude", "exclude files or directories from parsing")
 	}
 	e.Usage = Usage(os.Stderr, e.FlagSet)
 	return e.FlagSet

--- a/cmd/pkger/cmds/pack.go
+++ b/cmd/pkger/cmds/pack.go
@@ -32,6 +32,7 @@ type packCmd struct {
 	out     string
 	help    bool
 	include slice
+	exclude slice
 	subs    []command
 }
 
@@ -48,7 +49,7 @@ func (e *packCmd) Exec(args []string) error {
 	fp := filepath.Join(info.Dir, e.out, outName)
 	os.RemoveAll(fp)
 
-	decls, err := parser.Parse(info, e.include...)
+	decls, err := parser.Parse(info, e.include, e.exclude)
 	if err != nil {
 		return err
 	}
@@ -105,6 +106,7 @@ func New() (*packCmd, error) {
 	c.BoolVar(&c.help, "h", false, "prints help information")
 	c.StringVar(&c.out, "o", "", "output directory for pkged.go")
 	c.Var(&c.include, "include", "packages the specified file or directory")
+	c.Var(&c.exclude, "exclude", "exclude files or directories from parsing")
 	c.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage:\n\n")
 		Usage(os.Stderr, c.FlagSet)()

--- a/cmd/pkger/cmds/parse.go
+++ b/cmd/pkger/cmds/parse.go
@@ -60,7 +60,7 @@ func (c *parseCmd) Exec(args []string) error {
 			}
 
 		}
-		decls, err := parser.Parse(info)
+		decls, err := parser.Parse(info, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -28,15 +28,17 @@ type Parser struct {
 	decls    map[string]Decls
 	once     sync.Once
 	includes []string
+	excludes []string
 	err      error
 }
 
-func Parse(her here.Info, includes ...string) (Decls, error) {
+func Parse(her here.Info, includes []string, excludes []string) (Decls, error) {
 	p, err := New(her)
 	if err != nil {
 		return nil, err
 	}
 	p.includes = includes
+	p.excludes = excludes
 
 	return p.Decls()
 }
@@ -200,7 +202,7 @@ func (p *Parser) parse() error {
 		}
 
 		base := filepath.Base(path)
-		for _, x := range defaultIgnoredFolders {
+		for _, x := range append(defaultIgnoredFolders, p.excludes...) {
 			if strings.HasPrefix(base, x) {
 				return filepath.SkipDir
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -31,7 +31,7 @@ func Test_Parser_Ref(t *testing.T) {
 	_, err = pkgtest.LoadFiles("/", ref, disk)
 	r.NoError(err)
 
-	res, err := Parse(ref.Info)
+	res, err := Parse(ref.Info, nil, nil)
 
 	r.NoError(err)
 
@@ -60,7 +60,7 @@ func Test_Parser_Ref_Include(t *testing.T) {
 	_, err = pkgtest.LoadFiles("/", ref, disk)
 	r.NoError(err)
 
-	res, err := Parse(ref.Info, "github.com/stretchr/testify:/go.mod")
+	res, err := Parse(ref.Info, []string{"github.com/stretchr/testify:/go.mod"}, nil)
 
 	r.NoError(err)
 
@@ -69,6 +69,34 @@ func Test_Parser_Ref_Include(t *testing.T) {
 
 	l := len(files)
 	r.Equal(26, l)
+}
+
+func Test_Parser_Ref_Exclude(t *testing.T) {
+	defer func() {
+		c := exec.Command("go", "mod", "tidy", "-v")
+		c.Run()
+	}()
+	r := require.New(t)
+
+	ref, err := pkgtest.NewRef()
+	r.NoError(err)
+	defer os.RemoveAll(ref.Dir)
+
+	disk, err := stdos.New(ref.Info)
+	r.NoError(err)
+
+	_, err = pkgtest.LoadFiles("/", ref, disk)
+	r.NoError(err)
+
+	res, err := Parse(ref.Info, nil, []string{"models"})
+
+	r.NoError(err)
+
+	files, err := res.Files()
+	r.NoError(err)
+
+	l := len(files)
+	r.Equal(24, l)
 }
 
 func Test_Parser_dotGo_Directory(t *testing.T) {
@@ -87,7 +115,7 @@ func Test_Parser_dotGo_Directory(t *testing.T) {
 	_, err = pkgtest.LoadFiles("/", ref, disk)
 	r.NoError(err)
 
-	res, err := Parse(ref.Info)
+	res, err := Parse(ref.Info, nil, nil)
 	r.NoError(err)
 	r.Equal(11, len(res))
 }
@@ -108,7 +136,7 @@ func Test_Parser_Example_HTTP(t *testing.T) {
 	her, err := here.Dir(root)
 	r.NoError(err)
 
-	res, err := Parse(her)
+	res, err := Parse(her, nil, nil)
 	r.NoError(err)
 
 	files, err := res.Files()


### PR DESCRIPTION
Continuing work from https://github.com/markbates/pkger/pull/108 on adding an `-exclude` flag for ignoring particular directories to both the list and pack commands. Includes tests and documentation.

Tests fail at the moment, but mostly due to bugs within the testing framework as I've laid out in  https://github.com/markbates/pkger/pull/108#issuecomment-656200823:
> Tests fail though, as they do on the main branch atm. @markbates to me it occurs that there is a bug in `pkging/pkgtest` that will somehow keep references to the first directory created by `pkgtest.NewRef()` for subsequent tests. As the first directory will be deleted after the first test passed, subsequent tests will fail due to the missing directory. Didn't find a solution for that bug, but if you comment out line 26 in the above `parser_test.go`, tests for the `excludes` argument will pass.