### PR TITLE
Make the list subcommand read-only

### DIFF
--- a/cmd/pkger/cmds/list.go
+++ b/cmd/pkger/cmds/list.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/markbates/pkger"
 	"github.com/markbates/pkger/parser"
@@ -38,9 +37,6 @@ func (e *listCmd) Exec(args []string) error {
 	if err != nil {
 		return err
 	}
-
-	fp := filepath.Join(info.Dir, outName)
-	os.RemoveAll(fp)
 
 	decls, err := parser.Parse(info, e.include...)
 	if err != nil {


### PR DESCRIPTION
I was using `pkger list` for debugging and found that it removed the `pkged.go` file on each run. I feel like this may have been left in for debugging as it doesn't make a ton of sense for the list command to modify files.