### PR TITLE
Use base64-encoding in favor of hex-encoding

### DIFF
--- a/pkging/embed/embed.go
+++ b/pkging/embed/embed.go
@@ -3,15 +3,15 @@ package embed
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/hex"
+	"encoding/base64"
 	"io"
 
 	"github.com/markbates/pkger/here"
 )
 
 func Decode(src []byte) ([]byte, error) {
-	dst := make([]byte, hex.DecodedLen(len(src)))
-	_, err := hex.Decode(dst, src)
+	dst := make([]byte, base64.RawStdEncoding.DecodedLen(len(src)))
+	_, err := base64.RawStdEncoding.Decode(dst, src)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func Encode(b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	s := hex.EncodeToString(bb.Bytes())
+	s := base64.RawStdEncoding.EncodeToString(bb.Bytes())
 	return []byte(s), nil
 }
 


### PR DESCRIPTION
Hi 👋,

I noticed, that the embedded data is serialized using hex-encoding, which increases the file size of the generated `pkged.go` as well as the compiled binary. Using base64-encoding instead can reduce this overhead and is also only a small code change.

Hex-encoding has a ratio of 2:1, so every (gzipped) byte translates to 2 bytes of serialized data.
On the other hand base64-encoding only has a ratio of 4:3, so every 3 bytes of (gzipped) data result in 4 bytes of serialized data.

So with this commit every MB of packaged assets (after gzip) only ends up in ~1,333 MB instead of 2 MB in the binary.