### PR TITLE
Add missing error handling

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -84,6 +84,9 @@ func (p *Parser) ParseFile(abs string, mode parser.Mode) (*ParsedSource, error) 
 	}
 
 	s.Path, err = s.Here.Parse(strings.TrimPrefix(abs, dir))
+	if err != nil {
+		return nil, err
+	}
 
 	return p.ParseSource(s, 0)
 }

--- a/pkging/pkgutil/stuff.go
+++ b/pkging/pkgutil/stuff.go
@@ -57,5 +57,5 @@ func Stuff(w io.Writer, c here.Info, decls parser.Decls) error {
 	}
 
 	_, err = w.Write(b)
-	return nil
+	return err
 }


### PR DESCRIPTION
It looks like these checks were just forgotten. Should we intentionally
ignore errors here, we should probably unassign err.