### PR TITLE
remove defer clean(), disable go mod tidy in defer

### DIFF
--- a/cmd/pkger/main.go
+++ b/cmd/pkger/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+
 	clean := func() {
 		c := exec.Command("go", "mod", "tidy")
 		c.Stdout = os.Stdout
@@ -16,7 +17,6 @@ func main() {
 		c.Stdin = os.Stdin
 		c.Run()
 	}
-	defer clean()
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -29,6 +29,7 @@ func main() {
 		clean()
 		log.Fatal(err)
 	}
+
 }
 
 func run() error {


### PR DESCRIPTION
"Go mod Tidy" does not run well in some projects, and there are inappropriate prompt messages when pkger succeeds.